### PR TITLE
fix: clean templates list string to avoid basic errors

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -58,7 +58,8 @@ async def get_template(templates: str):
     Example:
         `https://donotcommit.com/api/python,lua,zig`
     """
-    templates_names = templates.split(',')
+    templates = templates.strip(', ')
+    templates_names = [name.strip() for name in templates.split(',')]
 
     gitignore_response = ''
     for template in templates_names:


### PR DESCRIPTION
By seeing logs in Pydantic Logfire board, I could see people not always passes the templates list as specified. I made a slightly better cleanup job now. Hope it will help people use our API more comfortably!

With the merge of this pull request, the call with the path `/api/,python,lua ,zig,` should work fine!